### PR TITLE
chore: EX-1155: ownership files update

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -22,7 +22,7 @@ metadata:
 
 spec:
   type: library
-  owner: group:layout-architecture
+  owner: group:dev-ecosystem
   criticality: low
   capability: web-sdk
   lifecycle: production

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -22,7 +22,7 @@ metadata:
 
 spec:
   type: library
-  owner: app-frameworks
+  owner: group:layout-architecture
   criticality: low
   capability: web-sdk
   lifecycle: production


### PR DESCRIPTION
## Motivation
Approximately 685 entities currently belong to orphaned groups, resulting in invalid ownership for 47.3% of all registered entities. To ensure clarity of ownership across all entity types—including APIs, capabilities, components, user journeys, and more—the following changes are necessary.

Ownership for various entity types was determined using available data from the current Amped structure. Teams with a carryover score exceeding 50% were considered to have a 1:1 ownership mapping. For entities previously owned by teams with less than 50% carryover, ownership was assigned based on the commit history of the specific entity.

## Proposed Changes

### YAML File Updates:
- Update all YAML files to reference valid Amped groups.
- Introduce the new Backstage group reference format: owner: group:{team-name}.

### CODEOWNERS File Updates:
- Replace all references to the orphaned groups in ./CODEOWNERS and .github/CODEOWNERS with the corresponding valid AMPED team name.
- Grant "write" permissions to the corresponding GitHub team associated with the AMPED team.

## Next Steps
Teams review all components are rightly assigned to them as needed using Backstage.  

## Reference Ticket and Useful Documentation
[Jira epic](https://miro.atlassian.net/browse/EX-1155)  
[Doc](https://miro.atlassian.net/wiki/spaces/PT/pages/4086104154/Managing+Component+Ownership+After+Team+Changes)
